### PR TITLE
Update Dockerfile to use newer rs2 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM gliderlabs/alpine:3.2
 MAINTAINER Jan Broer <janeczku@yahoo.com>
 
 RUN apk-install -t build-dependencies wget ca-certificates \
-  && wget -q -O - https://github.com/papertrail/remote_syslog2/releases/download/v0.15/remote_syslog_linux_amd64.tar.gz \
+  && wget -q -O - https://github.com/papertrail/remote_syslog2/releases/download/v0.18/remote_syslog_linux_amd64.tar.gz \
   | tar -zxf - \
   && apk del build-dependencies
 


### PR DESCRIPTION
remote_syslog2 has been updated a few times since this was created; worth using the latest version if for nothing else but supporting the new SHA2 certificates used for `logsN.papertrailapp.com`.
