### PR TITLE
Add -D for command line case as well

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,5 +8,5 @@ if [[ -z ${1} ]]; then
   	--tcp=${SYSLOG_TCP:-false} --tls=${SYSLOG_TLS:-false} --facility=${SYSLOG_FACILITY:-user} \
   	--severity=${SYSLOG_SEVERITY:-notice} --hostname=${SYSLOG_HOSTNAME} ${SYSLOG_FILES}
 else
-  exec /remote_syslog/remote_syslog $@
+  exec /remote_syslog/remote_syslog -D $@
 fi


### PR DESCRIPTION
Without -D, the container exits immediately, and can't send logs effectively, so it makes sense to include it in both cases.